### PR TITLE
Remove duplicate unset() in the decompile() method.

### DIFF
--- a/src/Crell/ApiProblem/ApiProblem.php
+++ b/src/Crell/ApiProblem/ApiProblem.php
@@ -175,15 +175,12 @@ class ApiProblem implements \ArrayAccess
 
         if (!empty($parsed['httpStatus'])) {
             $problem->setHttpStatus($parsed['httpStatus']);
-            unset($parsed['httpStatus']);
         }
         if (!empty($parsed['detail'])) {
             $problem->setDetail($parsed['detail']);
-            unset($parsed['detail']);
         }
         if (!empty($parsed['problemInstance'])) {
             $problem->setProblemInstance($parsed['problemInstance']);
-            unset($parsed['problemInstance']);
         }
 
         // Remove the defined keys. That means whatever is left must be a custom


### PR DESCRIPTION
It's looking good Larry, spotted what I think is unnecessary repetition of unset() in the decompile method which I've removed in this pull request.
