### PR TITLE
Add an "asArray()" method to get the compiled data as a native PHP array

### DIFF
--- a/src/Crell/ApiProblem/ApiProblem.php
+++ b/src/Crell/ApiProblem/ApiProblem.php
@@ -344,6 +344,16 @@ class ApiProblem implements \ArrayAccess
     }
 
     /**
+     * Renders this problem as a native PHP array.
+     *
+     * @return array
+     */
+    public function asArray()
+    {
+        return $this->compile();
+    }
+
+    /**
      * Renders this problem as JSON.
      *
      * @param boolean $pretty


### PR DESCRIPTION
Awesome project.

It would be great to add an `ApiProblem::asArray()` method to get the compiled data as a native PHP array. The use case I have is to more easily integrate this project into a Silex app, where JSON data is returned by adding the following statement to your callback:

```
$app->error(function (\Exception $e, $code) use ($app) {
  // ...
  return $app->json($data);
});
```

Without a method to get a native PHP array, I have to re-implement some header-setting in the `json()` method in order for things to be treated the same way as JSON in the rest of the application.

Thanks in advance for any attention you can give to this,
Chris
