### PR TITLE
Makes codeclimate/php-test-reporter a dev dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
         "psr-4": {"Crell\\ApiProblem\\": "src/"}
     },
     "require": {
-        "php": ">=5.3.3",
-        "codeclimate/php-test-reporter": "dev-master"
+        "php": ">=5.3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.7.*",
+        "codeclimate/php-test-reporter": "dev-master"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Hey @Crell!

I am incorporating this into an API I'm working on and was curious whether or not the test reporter from CodeClimate was a production dependency of the package. Anywho, figured I'd frame the question as a PR in case it was more appropriate as a dev-dependency. If not, feel free to close!

Thanks for taking this on; looks great!