### PR TITLE
Issue #26 support rendering using json_encode()

### DIFF
--- a/src/ApiProblem.php
+++ b/src/ApiProblem.php
@@ -26,7 +26,7 @@ namespace Crell\ApiProblem;
  *
  * @autor Larry Garfield
  */
-class ApiProblem implements \ArrayAccess
+class ApiProblem implements \ArrayAccess, \JsonSerializable
 {
 
     /**
@@ -431,8 +431,20 @@ class ApiProblem implements \ArrayAccess
      *
      * @return array
      *   The API problem represented as an array.
-    */
+     */
     public function asArray() : array
+    {
+        return $this->compile();
+    }
+
+    /**
+     * Supports rendering this problem as a JSON using the
+     * json_encode() function.
+     *
+     * @return array
+     *   The API problem represented as an array for rendering.
+     */
+    public function jsonSerialize()
     {
         return $this->compile();
     }

--- a/src/ApiProblem.php
+++ b/src/ApiProblem.php
@@ -438,8 +438,7 @@ class ApiProblem implements \ArrayAccess, \JsonSerializable
     }
 
     /**
-     * Supports rendering this problem as a JSON using the
-     * json_encode() function.
+     * Supports rendering this problem as a JSON using the json_encode() function.
      *
      * @return array
      *   The API problem represented as an array for rendering.

--- a/tests/ApiProblemTest.php
+++ b/tests/ApiProblemTest.php
@@ -99,6 +99,22 @@ class ApiProblemTest extends TestCase
         $this->assertEquals('Zim', $result['irken']['invader']);
     }
 
+    public function testSimpleJsonEncode() : void
+    {
+        $problem = new ApiProblem('Title', 'URI');
+
+        $json = json_encode($problem);
+        $result = json_decode($json, true);
+
+        $this->assertArrayHasKey('title', $result);
+        $this->assertEquals('Title', $result['title']);
+        $this->assertArrayHasKey('type', $result);
+        $this->assertEquals('URI', $result['type']);
+
+        // Ensure that empty properties are not included.
+        $this->assertArrayNotHasKey('detail', $result);
+    }
+
     /**
      * Confirms that the title property is optional.
      *


### PR DESCRIPTION
Simple `JsonSerializable` support.

This is useful in frameworks such as Laravel or Lumen that will accept any object as a HTTP response payload that can be JSON serialised.