### PR TITLE
Adding ApiProblem::fromArray named constructor

### DIFF
--- a/src/ApiProblem.php
+++ b/src/ApiProblem.php
@@ -186,6 +186,15 @@ class ApiProblem implements \ArrayAccess, \JsonSerializable
         return static::decompile($data);
     }
 
+    public static function fromArray(array $input) : self
+    {
+        $defaultInput = ['title' => null, 'type' => null, 'status' => null, 'detail' => null, 'instance' => null];
+
+        $data = $input + $defaultInput;
+
+        return self::decompile($data);
+    }
+
     /**
      * Decompiles an array into an ApiProblem object.
      *

--- a/src/ApiProblem.php
+++ b/src/ApiProblem.php
@@ -186,6 +186,14 @@ class ApiProblem implements \ArrayAccess, \JsonSerializable
         return static::decompile($data);
     }
 
+    /**
+     * Parses an array into a Problem object.
+     *
+     * @param array $input
+     *   The array to parse.
+     * @return ApiProblem
+     *   A newly constructed problem object.
+     */
     public static function fromArray(array $input) : self
     {
         $defaultInput = ['title' => null, 'type' => null, 'status' => null, 'detail' => null, 'instance' => null];

--- a/tests/ApiProblemTest.php
+++ b/tests/ApiProblemTest.php
@@ -257,5 +257,31 @@ class ApiProblemTest extends TestCase
         $json = $problem->asJson(true);
         $this->assertTrue(strpos($json, '  ') !== FALSE);
     }
+
+    public function testParseFromArrayWithEmptyArray() : void
+    {
+        $problem = new ApiProblem();
+        $problemFromArray = ApiProblem::fromArray([]);
+
+        $this->assertEquals($problem, $problemFromArray);
+    }
+
+    public function testParseFromArray() : void
+    {
+        $problem = new ApiProblem('Title', 'URI');
+        $problem->setStatus(403);
+        $problem['sir'] = 'Gir';
+        $problem['irken']['invader'] = 'Zim';
+
+        $newProblem = ApiProblem::fromArray($problem->asArray());
+
+        $this->assertEquals($problem['sir'], $newProblem['sir']);
+        $this->assertEquals($problem->getTitle(), $newProblem->getTitle());
+        $this->assertEquals($problem->getType(), $newProblem->getType());
+        $this->assertEquals($problem->getStatus(), $newProblem->getStatus());
+        $this->assertEquals($problem->getDetail(), $newProblem->getDetail());
+        $this->assertEquals($problem->getInstance(), $newProblem->getInstance());
+        $this->assertEquals($problem['irken']['invader'], $newProblem['irken']['invader']);
+    }
 }
 


### PR DESCRIPTION
This PR is to resolve #24 

It adds a `ApiProblem::fromArray` named constructor by wrapping the already existing protected method `ApiProblem::decompile` and make sure that it does not fails with array missing the required ApiProblem keys