### PR TITLE
Removing empty usage on decoding

### DIFF
--- a/src/ApiProblem.php
+++ b/src/ApiProblem.php
@@ -215,26 +215,28 @@ class ApiProblem implements \ArrayAccess, \JsonSerializable
     {
         $problem = new static();
 
-        if (isset($parsed['title']) && $parsed['title'] !== '') {
+        // Skip empty string or missing values.
+        // The string or integer 0, however, are allowed.  PHP makes
+        // this ugly. The check on string handles XML decompile which
+        // may return an empty array.
+        $emptyValues = ['', []];
+        if (isset($parsed['title']) && !in_array($parsed['title'], $emptyValues, true)) {
             $problem->setTitle($parsed['title']);
         }
 
-        if (isset($parsed['type']) && $parsed['type'] !== '') {
+        if (isset($parsed['type']) && !in_array($parsed['type'], $emptyValues, true)) {
             $problem->setType($parsed['type']);
         }
 
-        if (isset($parsed['status'])) {
-            $status = (int) $parsed['status'];
-            if ($status !== 0) {
-                $problem->setStatus($status);
-            }
+        if (isset($parsed['status']) && ($status = filter_var($parsed['status'], FILTER_VALIDATE_INT)) !== false) {
+            $problem->setStatus($status);
         }
 
-        if (isset($parsed['detail']) && $parsed['detail'] !== '') {
+        if (isset($parsed['detail']) && !in_array($parsed['detail'], $emptyValues, true)) {
             $problem->setDetail($parsed['detail']);
         }
 
-        if (isset($parsed['instance']) && $parsed['instance'] !== '') {
+        if (isset($parsed['instance']) && !in_array($parsed['instance'], $emptyValues, true)) {
             $problem->setInstance($parsed['instance']);
         }
 

--- a/src/ApiProblem.php
+++ b/src/ApiProblem.php
@@ -135,7 +135,7 @@ class ApiProblem implements \ArrayAccess, \JsonSerializable
      */
     public static function fromJson(string $json) : self
     {
-        if (empty($json)) {
+        if ($json === '') {
             throw new JsonParseException('An empty string is not a valid JSON value', JSON_ERROR_SYNTAX, null, $json);
         }
         $parsed = json_decode($json, true);
@@ -215,20 +215,26 @@ class ApiProblem implements \ArrayAccess, \JsonSerializable
     {
         $problem = new static();
 
-
-        if (!empty($parsed['title'])) {
+        if (isset($parsed['title']) && $parsed['title'] !== '') {
             $problem->setTitle($parsed['title']);
         }
-        if (!empty($parsed['type'])) {
+
+        if (isset($parsed['type']) && $parsed['type'] !== '') {
             $problem->setType($parsed['type']);
         }
-        if (!empty($parsed['status'])) {
-            $problem->setStatus((int) $parsed['status']);
+
+        if (isset($parsed['status'])) {
+            $status = (int) $parsed['status'];
+            if ($status !== 0) {
+                $problem->setStatus($status);
+            }
         }
-        if (!empty($parsed['detail'])) {
+
+        if (isset($parsed['detail']) && $parsed['detail'] !== '') {
             $problem->setDetail($parsed['detail']);
         }
-        if (!empty($parsed['instance'])) {
+
+        if (isset($parsed['instance']) && $parsed['instance'] !== '') {
             $problem->setInstance($parsed['instance']);
         }
 

--- a/tests/ApiProblemTest.php
+++ b/tests/ApiProblemTest.php
@@ -315,15 +315,13 @@ class ApiProblemTest extends TestCase
 
     public function testJsonWithFalsyFieldsIsCorrectlyConverted(): void
     {
+        $input = '{"title":"0", "type":"", "detail":"0", "instance":"0", "status":0}';
         $expected = [
             "title"=> "0",
-            "type"=> "0",
+            "type"=> "about:blank",
             "detail"=> "0",
             "instance" => "0",
         ];
-
-        /** @var string $input */
-        $input = json_encode($expected + ['status' => 0]);
 
         self::assertSame($expected, ApiProblem::fromJson($input)->asArray());
     }
@@ -339,7 +337,23 @@ class ApiProblemTest extends TestCase
 
     public function testXmlWithEmptyTypeIsConvertedtoAboutBlank(): void
     {
-        $xml = '<?xml version="1.0"?>'."\n".'<problem><type></type><status>23foobar</status></problem>'."\n";
+        $xml = '<?xml version="1.0"?>'."\n".'<problem><type></type></problem>'."\n";
+        $arr = ["type" => "about:blank"];
+
+        self::assertSame($arr, ApiProblem::fromXml($xml)->asArray());
+    }
+
+    public function testXmlWithInvalidStatusIsSkipped(): void
+    {
+        $xml = '<?xml version="1.0"?>'."\n".'<problem><status>23foobar</status></problem>'."\n";
+        $arr = ["type" => "about:blank"];
+
+        self::assertSame($arr, ApiProblem::fromXml($xml)->asArray());
+    }
+
+    public function testXmlWithFloatStatusIsSkipped(): void
+    {
+        $xml = '<?xml version="1.0"?>'."\n".'<problem><status>2.3</status></problem>'."\n";
         $arr = ["type" => "about:blank"];
 
         self::assertSame($arr, ApiProblem::fromXml($xml)->asArray());

--- a/tests/ApiProblemTest.php
+++ b/tests/ApiProblemTest.php
@@ -327,5 +327,22 @@ class ApiProblemTest extends TestCase
 
         self::assertSame($expected, ApiProblem::fromJson($input)->asArray());
     }
+
+    public function testXmlWithFalsyFieldsIsCorrectlyConverted(): void
+    {
+        $xml = '<?xml version="1.0"?>'."\n".'<problem><type>0</type><status>400</status></problem>'."\n";
+        $arr = ["type" => "0", "status" => 400];
+
+        self::assertSame($arr, ApiProblem::fromXml($xml)->asArray());
+        self::assertSame($xml, ApiProblem::fromArray($arr)->asXml());
+    }
+
+    public function testXmlWithEmptyTypeIsConvertedtoAboutBlank(): void
+    {
+        $xml = '<?xml version="1.0"?>'."\n".'<problem><type></type><status>23foobar</status></problem>'."\n";
+        $arr = ["type" => "about:blank"];
+
+        self::assertSame($arr, ApiProblem::fromXml($xml)->asArray());
+    }
 }
 

--- a/tests/ApiProblemTest.php
+++ b/tests/ApiProblemTest.php
@@ -312,5 +312,20 @@ class ApiProblemTest extends TestCase
 
         self::assertSame($expected, $problem->asArray());
     }
+
+    public function testJsonWithFalsyFieldsIsCorrectlyConverted(): void
+    {
+        $expected = [
+            "title"=> "0",
+            "type"=> "0",
+            "detail"=> "0",
+            "instance" => "0",
+        ];
+
+        /** @var string $input */
+        $input = json_encode($expected + ['status' => 0]);
+
+        self::assertSame($expected, ApiProblem::fromJson($input)->asArray());
+    }
 }
 


### PR DESCRIPTION
As a follow up to #33 I'm also removing `empty` usage on decompiling the Problem object to remove the following bug

```php
<?php

echo ApiProblem::fromJson('{"type":"0"}')->asJson();
// expected {"type":"0"} but got {"type":"about:blank"} instead
```