### PR TITLE
Feature/add problem interface

### DIFF
--- a/src/ApiProblem.php
+++ b/src/ApiProblem.php
@@ -26,9 +26,8 @@ namespace Crell\ApiProblem;
  *
  * @autor Larry Garfield
  */
-class ApiProblem implements \ArrayAccess, \JsonSerializable
+class ApiProblem implements Problem, \ArrayAccess, \JsonSerializable
 {
-
     /**
      * The content type for a JSON based HTTP response carrying
      * problem details.
@@ -319,10 +318,7 @@ class ApiProblem implements \ArrayAccess, \JsonSerializable
     }
 
     /**
-     * Retrieves the title of the problem.
-     *
-     * @return string
-     *   The current title.
+     * {@inheritdoc}
      */
     public function getTitle() : string
     {
@@ -330,24 +326,16 @@ class ApiProblem implements \ArrayAccess, \JsonSerializable
     }
 
     /**
-     * Sets the title for this problem.
-     *
-     * @param string $title
-     *   The title to set.
-     *  @return ApiProblem
-     *   The invoked object.
+     * {@inheritdoc}
      */
-    public function setTitle(string $title) : self
+    public function setTitle(string $title) : Problem
     {
         $this->title = $title;
         return $this;
     }
 
     /**
-     * Retrieves the problem type of this problem.
-     *
-     * @return string
-     *   The problem type URI of this problem.
+     * {@inheritdoc}
      */
     public function getType() : string
     {
@@ -355,24 +343,16 @@ class ApiProblem implements \ArrayAccess, \JsonSerializable
     }
 
     /**
-     * Sets the problem type of this problem.
-     *
-     * @param string $type
-     *   The resolvable problem type URI of this problem.
-     * @return ApiProblem
-     *   The invoked object.
+     * {@inheritdoc}
      */
-    public function setType(string $type) : self
+    public function setType(string $type) : Problem
     {
         $this->type = $type;
         return $this;
     }
 
     /**
-     * Retrieves the detail information of the problem.
-     *
-     * @return string
-     *   The detail of this problem.
+     * {@inheritdoc}
      */
     public function getDetail() : string
     {
@@ -380,24 +360,16 @@ class ApiProblem implements \ArrayAccess, \JsonSerializable
     }
 
     /**
-     * Sets the detail for this problem.
-     *
-     * @param string $detail
-     *   The human-readable detail string about this problem.
-     * @return ApiProblem
-     *   The invoked object.
+     * {@inheritdoc}
      */
-    public function setDetail(string $detail) : self
+    public function setDetail(string $detail) : Problem
     {
         $this->detail = $detail;
         return $this;
     }
 
     /**
-     * Returns the problem instance URI of this problem.
-     *
-     * @return string
-     *   The problem instance URI of this problem.
+     * {@inheritdoc}
      */
     public function getInstance() : string
     {
@@ -405,26 +377,16 @@ class ApiProblem implements \ArrayAccess, \JsonSerializable
     }
 
     /**
-     * Sets the problem instance URI of this problem.
-     *
-     * @param string $instance
-     *   An absolute URI that uniquely identifies this problem. It MAY link to
-     *   further information about the error, but that is not required.
-     *
-     * @return ApiProblem
-     *   The invoked object.
+     * {@inheritdoc}
      */
-    public function setInstance(string $instance) : self
+    public function setInstance(string $instance) : Problem
     {
         $this->instance = $instance;
         return $this;
     }
 
     /**
-     * Returns the current HTTP status code.
-     *
-     * @return int
-     *   The current HTTP status code. If not set, it will return 0.
+     * {@inheritdoc}
      */
     public function getStatus() : int
     {
@@ -432,17 +394,9 @@ class ApiProblem implements \ArrayAccess, \JsonSerializable
     }
 
     /**
-     * Sets the HTTP status code for this problem.
-     *
-     * It is an error for this value to be set to a different value than the
-     * actual HTTP response code.
-     *
-     * @param int $status
-     *   A valid HTTP status code.
-     * @return ApiProblem
-     *   The invoked object.
+     * {@inheritdoc}
      */
-    public function setStatus(int $status) : self
+    public function setStatus(int $status) : Problem
     {
         $this->status = $status;
         return $this;
@@ -482,7 +436,7 @@ class ApiProblem implements \ArrayAccess, \JsonSerializable
      * @return string
      *   An XML string representing this problem.
      */
-    public function asXml(bool $pretty = false)
+    public function asXml(bool $pretty = false): string
     {
         $doc = new \SimpleXMLElement('<problem></problem>');
 
@@ -498,13 +452,7 @@ class ApiProblem implements \ArrayAccess, \JsonSerializable
     }
 
     /**
-     * Renders this problem as a native PHP array.
-     *
-     * This is mostly useful for debugging, or for placing
-     * this problem response into, say, a Symfony JsonResponse object.
-     *
-     * @return array
-     *   The API problem represented as an array.
+     * {@inheritdoc}
      */
     public function asArray() : array
     {
@@ -560,7 +508,7 @@ class ApiProblem implements \ArrayAccess, \JsonSerializable
      * @param mixed $parent
      *   Used for internal recursion only.
      */
-    protected function arrayToXml(array $data, \SimpleXMLElement $element, $parent = null)
+    protected function arrayToXml(array $data, \SimpleXMLElement $element, $parent = null): void
     {
         foreach ($data as $key => $value) {
             if (is_array($value)) {
@@ -591,6 +539,23 @@ class ApiProblem implements \ArrayAccess, \JsonSerializable
                 }
             }
         }
+    }
+
+    public function getExtensions(): array
+    {
+        return $this->extensions;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setExtensions(iterable $extensions): Problem
+    {
+        foreach ($extensions as $name => $value) {
+            $this->offsetSet($name, $value);
+        }
+
+        return $this;
     }
 
     /**

--- a/src/HttpConverter.php
+++ b/src/HttpConverter.php
@@ -41,45 +41,77 @@ class HttpConverter
     /**
      * Converts a problem to a JSON HTTP Response object, provided.
      *
-     * @param ApiProblem $problem
+     * @param Problem $problem
      *   The problem to convert.
      *
      * @return ResponseInterface
      *   The appropriate response object.
      */
-    public function toJsonResponse(ApiProblem $problem) : ResponseInterface
+    public function toJsonResponse(Problem $problem) : ResponseInterface
     {
-        $response = $this->toResponse($problem);
+        $response = $this
+            ->toResponse($problem)
+            ->withHeader('Content-Type', ApiProblem::CONTENT_TYPE_JSON)
+        ;
+
+        $content = $this->problemToJsonString($problem);
 
         $body = $response->getBody();
-        $body->write($problem->asJson($this->pretty));
+        $body->write($content);
         $body->rewind();
 
-        return $response
-            ->withHeader('Content-Type', ApiProblem::CONTENT_TYPE_JSON)
-            ->withBody($body);
+        return $response;
     }
 
     /**
      * Converts a problem to an XML HTTP Response object, provided.
      *
-     * @param ApiProblem $problem
+     * @param Problem $problem
      *   The problem to convert.
      *
      * @return ResponseInterface
      *   The appropriate response object.
      */
-    public function toXmlResponse(ApiProblem $problem) : ResponseInterface
+    public function toXmlResponse(Problem $problem) : ResponseInterface
     {
-        $response = $this->toResponse($problem);
+        $response = $this
+            ->toResponse($problem)
+            ->withHeader('Content-Type', ApiProblem::CONTENT_TYPE_XML)
+        ;
+
+        $content = $this->problemToXMLString($problem);
 
         $body = $response->getBody();
-        $body->write($problem->asXml($this->pretty));
+        $body->write($content);
         $body->rewind();
 
-        return $this->toResponse($problem)
-            ->withHeader('Content-Type', ApiProblem::CONTENT_TYPE_XML)
-            ->withBody($body);
+        return $response;
+    }
+
+    protected function problemToXMLString(Problem $problem): string
+    {
+        $doc = new \SimpleXMLElement('<problem></problem>');
+
+        $this->arrayToXml($problem->asArray(), $doc);
+
+        /** @var \DOMElement */
+        $dom = dom_import_simplexml($doc);
+        if ($this->pretty) {
+            $dom->ownerDocument->preserveWhiteSpace = false;
+            $dom->ownerDocument->formatOutput = true;
+        }
+
+        return $dom->ownerDocument->saveXML();
+    }
+
+    protected function problemToJsonString(Problem $problem): string
+    {
+        $options = 0;
+        if ($this->pretty) {
+            $options = \JSON_UNESCAPED_SLASHES | \JSON_PRETTY_PRINT;
+        }
+
+        return json_encode($problem->asArray(), $options);
     }
 
     /**
@@ -96,5 +128,52 @@ class HttpConverter
         $status = $problem->getStatus() ?: 500;
 
         return $this->responseFactory->createResponse($status);
+    }
+
+    /**
+     * Adds a nested array to a SimpleXML element.
+     *
+     * This method was shamelessly coped from the Nocarrier\Hal library:
+     *
+     * @link https://github.com/blongden/hal
+     *
+     * @param array $data
+     *   The data to add to the element.
+     * @param \SimpleXMLElement $element
+     *   The XML object to which to add data.
+     * @param mixed $parent
+     *   Used for internal recursion only.
+     */
+    protected function arrayToXml(array $data, \SimpleXMLElement $element, $parent = null): void
+    {
+        foreach ($data as $key => $value) {
+            if (is_array($value)) {
+                if (!is_numeric($key)) {
+                    if (count($value) > 0 && isset($value[0])) {
+                        $this->arrayToXml($value, $element, $key);
+                    } else {
+                        $subnode = $element->addChild($key);
+                        $this->arrayToXml($value, $subnode, $key);
+                    }
+                } else {
+                    $subnode = $element->addChild($parent);
+                    $this->arrayToXml($value, $subnode, $parent);
+                }
+            } else {
+                if (!is_numeric($key)) {
+                    if ($key[0] === '@') {
+                        $element->addAttribute(substr($key, 1), $value);
+                    } elseif ($key === 'value') {
+                        $element->{0} = $value;
+                    } elseif (is_bool($value)) {
+                        $element->addChild($key, strval($value));
+                    } else {
+                        $element->addChild($key, htmlspecialchars((string) $value, ENT_QUOTES));
+                    }
+                } else {
+                    $element->addChild($parent, htmlspecialchars($value, ENT_QUOTES));
+                }
+            }
+        }
     }
 }

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\ApiProblem;
+
+/**
+ * An API error of some form.
+ *
+ * This object generates errors in compliance with RFC 7807 "API Problem".
+ *
+ * This object should be configured via the appropriate methods, and then
+ * rendered using the asArray() or jsonSerialize() methods.
+ *
+ * For problem properties defined by the specification, use the methods provided
+ * to get/set those values.
+ *
+ * @link http://tools.ietf.org/html/rfc7807
+ */
+interface Problem
+{
+    /**
+     * Retrieves the problem type of this problem.
+     */
+    public function getType(): string;
+
+    /**
+     * Retrieves the title of the problem.
+     */
+    public function getTitle(): string;
+
+    /**
+     * Returns the current HTTP status code. If not set, it will return 0.
+     */
+    public function getStatus(): int;
+
+    /**
+     * Returns the problem instance URI of this problem.
+     */
+    public function getInstance(): string;
+
+    /**
+     * Retrieves the detail information of the problem.
+     */
+    public function getDetail(): string;
+
+    /**
+     * Retrieves the extensions members attached to the problem.
+     *
+     * @return array The extensions members of this problem.
+     */
+    public function getExtensions(): array;
+
+    /**
+     * Renders this problem as a native PHP array.
+     *
+     * @return array The API problem represented as an array.
+     */
+    public function asArray() : array;
+
+    /**
+     * Sets the problem type of this problem.
+     */
+    public function setType(string $type): Problem;
+
+    /**
+     * Sets the title for this problem.
+     */
+    public function setTitle(string $title): Problem;
+
+    /**
+     * Sets the detail for this problem.
+     */
+    public function setDetail(string $detail): Problem;
+
+    /**
+     * Sets the problem instance URI of this problem.
+     *
+     * An absolute URI that uniquely identifies this problem. It MAY link to
+     *  further information about the error, but that is not required.
+     */
+    public function setInstance(string $instance): Problem;
+
+    /**
+     * Sets the HTTP status code for this problem.
+     *
+     * It is an error for this value to be set to a different value than the
+     * actual HTTP response code.
+     */
+    public function setStatus(int $status): Problem;
+
+    /**
+     * Sets the problem extensions of this problem.
+     *
+     * @param iterable $extensions A collection of extensions member.
+     */
+    public function setExtensions(iterable $extensions): Problem;
+}

--- a/tests/ApiProblemTest.php
+++ b/tests/ApiProblemTest.php
@@ -358,5 +358,16 @@ class ApiProblemTest extends TestCase
 
         self::assertSame($arr, ApiProblem::fromXml($xml)->asArray());
     }
+
+    public function testItCanAcceptsIterableConstructForExtensions(): void
+    {
+        $data = ['foo' => 'bar', 'status' => 403];
+        $extensions = new \ArrayIterator($data);
+
+        $problem = new ApiProblem();
+        $problem->setExtensions($extensions);
+
+        self::assertSame($data, $problem->getExtensions());
+    }
 }
 


### PR DESCRIPTION
@Crell This PR tentatively tries to introduce an Interface for the `ApiProblem` package.

I say tentatively because I wonder if this should be done using something la PHP-FIG or if this is useful to enable swapping or using other package using object following RFC7807 like https://github.com/phpro/api-problem .


Also I tried to extract the interface without introducing any BC break

If you find this useful the remaining/open question are:

### Naming issues:

- should the interface be simply called `Problem` vs `ApiProblemInterface`
- should we used `Problem::toArray` vs `Problem::asArray`

### New methods/classes

- the `set/getExtensions` methods are added to enable access to the extension members easily
- should we introduce a specific Exception if a setter method fails ?

### Out of scope features

- Currently the `Problem` interface does not support the `JsonSerializable` or the `ArrayAccess` interface as such any conversion feature like `asXml` or `asJson` are not present in the interface and are specific to the current implementation.
- In contrary `asArray` is kept in the interface as the other representations can be infer from it. As a consequence, `HttpConverter` is rewritten internally to only work with the `asArray` method.
- Using PHP native JsonException as this requires at least a PHP requirement bump and maybe a full BC break.


let me know what you think
