### PR TITLE
Handle JSON_ERROR_NON_BACKED_ENUM

### DIFF
--- a/src/JsonException.php
+++ b/src/JsonException.php
@@ -22,6 +22,7 @@ class JsonException extends \InvalidArgumentException
         \JSON_ERROR_UNSUPPORTED_TYPE => 'A value of a type that cannot be encoded was given',
         \JSON_ERROR_INVALID_PROPERTY_NAME => 'A property name that cannot be encoded was given',
         \JSON_ERROR_UTF16 => 'Malformed UTF-16 characters, possibly incorrectly encoded',
+        \JSON_ERROR_NON_BACKED_ENUM => 'Value contains a non-backed enum which cannot be serialized.',
     ];
 
     /**


### PR DESCRIPTION
Handles new constant added since 8.1 (not currently documented in table but [exists here](https://www.php.net/manual/en/json.constants.php#constant.json-error-non-backed-enum)
